### PR TITLE
Add additional Eq constraints for class instances with Num constraints

### DIFF
--- a/src/Data/Semiring.hs
+++ b/src/Data/Semiring.hs
@@ -82,5 +82,5 @@ newtype Numeric a = Numeric { getNumeric :: a }
 instance Show a => Show (Numeric a) where
   show = show . getNumeric
 
-instance Num a => Semiring (Numeric a) where
+instance (Eq a, Num a) => Semiring (Numeric a) where
   zero = 0; one = 1; (.+.) = (+); (.*.) = (*)

--- a/src/Text/RegExp/Data.hs
+++ b/src/Text/RegExp/Data.hs
@@ -35,7 +35,7 @@ defaultSymWeight = id
 instance Weight c c Bool where
   symWeight = defaultSymWeight
 
-instance Num a => Weight c c (Numeric a) where
+instance (Eq a, Num a) => Weight c c (Numeric a) where
   symWeight = defaultSymWeight
 
 weighted :: Weight a b w => RegW w a -> RegW w b

--- a/src/Text/RegExp/Matching.hs
+++ b/src/Text/RegExp/Matching.hs
@@ -30,7 +30,7 @@ acceptPartial r = partialMatch r
 -- Computes in how many ways a word can be matched against a regular
 -- expression.
 -- 
-matchingCount :: Num a => RegExp c -> [c] -> a
+matchingCount :: (Eq a, Num a) => RegExp c -> [c] -> a
 matchingCount r = getNumeric . fullMatch r
 
 {-# SPECIALIZE matchingCount :: RegExp c -> [c] -> Int #-}
@@ -50,7 +50,7 @@ fullMatch (RegExp r) = matchW (weighted r)
 
 {-# SPECIALIZE fullMatch :: RegExp c -> [c] -> Bool #-}
 {-# SPECIALIZE fullMatch :: RegExp c -> [c] -> Numeric Int #-}
-{-# SPECIALIZE fullMatch :: Num a => RegExp c -> [c] -> Numeric a #-}
+{-# SPECIALIZE fullMatch :: (Eq a, Num a) => RegExp c -> [c] -> Numeric a #-}
 {-# SPECIALIZE fullMatch :: RegExp c -> [(Int,c)] -> Leftmost #-}
 {-# SPECIALIZE fullMatch :: RegExp c -> [c] -> Longest #-}
 {-# SPECIALIZE fullMatch :: RegExp c -> [(Int,c)] -> LeftLong #-}
@@ -67,7 +67,7 @@ partialMatch (RegExp r) = matchW (arb `seqW` weighted r `seqW` arb)
 
 {-# SPECIALIZE partialMatch :: RegExp c -> [c] -> Bool #-}
 {-# SPECIALIZE partialMatch :: RegExp c -> [c] -> Numeric Int #-}
-{-# SPECIALIZE partialMatch :: Num a => RegExp c -> [c] -> Numeric a #-}
+{-# SPECIALIZE partialMatch :: (Eq a, Num a) => RegExp c -> [c] -> Numeric a #-}
 {-# SPECIALIZE partialMatch :: RegExp c -> [(Int,c)] -> Leftmost #-}
 {-# SPECIALIZE partialMatch :: RegExp c -> [c] -> Longest #-}
 {-# SPECIALIZE partialMatch :: RegExp c -> [(Int,c)] -> LeftLong #-}
@@ -78,7 +78,7 @@ matchW r (c:cs) = final (foldl (shiftW zero) (shiftW one r c) cs)
 
 {-# SPECIALIZE matchW :: RegW Bool c -> [c] -> Bool #-}
 {-# SPECIALIZE matchW :: RegW (Numeric Int) c -> [c] -> Numeric Int #-}
-{-# SPECIALIZE matchW :: Num a => RegW (Numeric a) c -> [c] -> Numeric a #-}
+{-# SPECIALIZE matchW :: (Eq a, Num a) => RegW (Numeric a) c -> [c] -> Numeric a #-}
 {-# SPECIALIZE matchW :: RegW Leftmost (Int,c) -> [(Int,c)] -> Leftmost #-}
 {-# SPECIALIZE matchW :: RegW Longest c -> [c] -> Longest #-}
 {-# SPECIALIZE matchW :: RegW LeftLong (Int,c) -> [(Int,c)] -> LeftLong #-}


### PR DESCRIPTION
Hey, thanks for closing my other issue so fast. :-)

Here's one other GHC 7.4.1 thing. After this, weighted-regexp builds fine for me (also on 7.0.4).

Starting from GHC 7.4.1, the Num class no longer has Eq (or Show)
superclasses. Therefore, specifying Num as a constraing no longer
implies these class constraints, so we have to add them manually where
they are required.
