### PR TITLE
Bump array version upper bounds.

### DIFF
--- a/weighted-regexp.cabal
+++ b/weighted-regexp.cabal
@@ -22,7 +22,7 @@ Extra-Source-Files:     README.markdown CHANGES.markdown
 Library
   Build-Tools:          happy >= 1.17
   Build-Depends:        base >= 3 && < 5,
-                        array >= 0.1 && < 0.5
+                        array >= 0.1 && < 0.6
   HS-Source-Dirs:       src
   Exposed-Modules:      Text.RegExp,
                         Text.RegExp.Matching.Leftmost,


### PR DESCRIPTION
This makes this package build again on GHC 7.8 and newer.

There are very few Haskell libraries that I care about, but weighted-regexp is definitely one of those few. Being able to use arbitrary semirings during regex matching opens up some amazing possibilities (I've used it for breaking a bad stream cipher where I knew the structure of the plaintext well enough to write a regex to match it, for instance) and I would like for the library to keep working.

I don't even care that it hasn't been maintained for five years because it does a great job as it stands. But it would be nice to upgrade to current QuickCheck so the tests work again...